### PR TITLE
New function: get_instances_by_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Tools to integrate Fabric with Google Compute Engine (GCE).
     - *get_instance_zone_by_ip* - get the instance zone by it's IP adddress - useful for command that requires sending the instance zone since newer versions of `gcloud` do not perform a name lookup in all zones.
     - *get_instance_zone_by_name* - get the instance zone by the instance name
     - *get_instances_by_group* - get instances from a managed instance group
+    - *get_managed_instance_groups* - retrieve a list of all managed instance groups
     - *target_pool_add_instance* - add an instance to a target pool
     - *target_pool_remove_instance* - remove an instance from a target pool
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Tools to integrate Fabric with Google Compute Engine (GCE).
     - *get_instance_name_by_ip* - get instance name by IP address (when using roles and fabric uses the IP and you want to get the current instance name based on the IP of the currently executing host)
     - *get_instance_zone_by_ip* - get the instance zone by it's IP adddress - useful for command that requires sending the instance zone since newer versions of `gcloud` do not perform a name lookup in all zones.
     - *get_instance_zone_by_name* - get the instance zone by the instance name
+    - *get_instances_by_group* - get instances from a managed instance group
     - *target_pool_add_instance* - add an instance to a target pool
     - *target_pool_remove_instance* - remove an instance from a target pool
 

--- a/fabric_gce_tools/__init__.py
+++ b/fabric_gce_tools/__init__.py
@@ -74,7 +74,9 @@ def _build_instances_index(data):
             instanceData = instance
         elif instance.get("instance") != None:
             ## need to retrieve the instance itself, we're coming from an instance group
-            raw_instance_data = subprocess.check_output("gcloud compute instances describe %s --format=json" % instance["instance"].split("/")[-1], shell=True)
+            raw_instance_data = subprocess.check_output("gcloud compute instances describe %s --zone=%s --format=json" %
+                                                        (instance["instance"].split("/")[-1],
+                                                         instance["instance"].split("/")[-3]), shell=True)
             instanceData = json.loads(raw_instance_data)
 
         ip = instanceData.get("networkInterfaces", [{}])[0].get("accessConfigs", [{}])[0].get("natIP", None)

--- a/fabric_gce_tools/__init__.py
+++ b/fabric_gce_tools/__init__.py
@@ -72,7 +72,7 @@ def _build_instances_index():
             instanceData = instance
         elif instance.get("instance") != None:
             ## need to retrieve the instance itself, we're coming from an instance group
-            raw_instance_data = subprocess.check_output("gcloud compute instances describe %s --format=json", shell=True)
+            raw_instance_data = subprocess.check_output("gcloud compute instances describe %s --format=json" % instance["instance"].split("/")[-1], shell=True)
             instanceData = json.loads(raw_instance_data)
 
         ip = instanceData.get("networkInterfaces", [{}])[0].get("accessConfigs", [{}])[0].get("natIP", None)

--- a/fabric_gce_tools/__init__.py
+++ b/fabric_gce_tools/__init__.py
@@ -217,7 +217,7 @@ def update_roles_gce(use_cache=True, cache_expiration=86400, cache_path="~/.gcet
     env.roledefs.update(roles)
 
     _data_loaded = True
-    return data
+    return INSTANCES_CACHE
 
 
 __all__ = [

--- a/fabric_gce_tools/__init__.py
+++ b/fabric_gce_tools/__init__.py
@@ -190,6 +190,10 @@ def get_instance_zone_by_ip(ip):
 def get_instances_by_group(group, region, zone):
     return update_roles_gce(group_name=group, region=region, zone=zone)
 
+def get_managed_instance_groups():
+    raw_data = subprocess.check_output("gcloud compute instance-groups managed list --format=json", shell=True)
+    return json.loads(raw_data)
+
 def target_pool_add_instance(target_pool_name, instance_name, instance_zone):
     raw_data = subprocess.check_output("gcloud compute target-pools add-instances {target_pool} --instances {instance_name} {zone_flag} {zone} --format json".format(target_pool=target_pool_name, instance_name=instance_name, zone_flag=_get_zone_flag_name(), zone=instance_zone), shell=True)
 

--- a/fabric_gce_tools/__init__.py
+++ b/fabric_gce_tools/__init__.py
@@ -67,12 +67,17 @@ def _build_instances_index():
     INSTANCES_IP_INDEX= {}
 
     for instance in INSTANCES_CACHE:
-        if not instance["name"] in INSTANCES_NAME_INDEX:
+        if instance.get("name") != None and not instance["name"] in INSTANCES_NAME_INDEX:
             INSTANCES_NAME_INDEX[instance["name"]] = instance
+            instanceData = instance
+        elif instance.get("instance") != None:
+            ## need to retrieve the instance itself, we're coming from an instance group
+            raw_instance_data = subprocess.check_output("gcloud compute instances describe %s --format=json", shell=True)
+            instanceData = json.loads(raw_instance_data)
 
-        ip = instance.get("networkInterfaces", [{}])[0].get("accessConfigs", [{}])[0].get("natIP", None)
+        ip = instanceData.get("networkInterfaces", [{}])[0].get("accessConfigs", [{}])[0].get("natIP", None)
         if ip and not ip in INSTANCES_IP_INDEX:
-            INSTANCES_IP_INDEX[ip] = instance
+            INSTANCES_IP_INDEX[ip] = instanceData
 
 def _get_data(use_cache, cache_expiration, group_name=None, region=None, zone=None):
     global INSTANCES_CACHE

--- a/fabric_gce_tools/__init__.py
+++ b/fabric_gce_tools/__init__.py
@@ -60,13 +60,15 @@ def _get_zone_flag_name():
     return "--instances-zone"
 
 
-def _build_instances_index():
+def _build_instances_index(data):
     global INSTANCES_NAME_INDEX
     global INSTANCES_IP_INDEX
+    global INSTANCES_CACHE
     INSTANCES_NAME_INDEX = {}
-    INSTANCES_IP_INDEX= {}
+    INSTANCES_IP_INDEX = {}
+    allInstanceData = []
 
-    for instance in INSTANCES_CACHE:
+    for instance in data:
         if instance.get("name") != None and not instance["name"] in INSTANCES_NAME_INDEX:
             INSTANCES_NAME_INDEX[instance["name"]] = instance
             instanceData = instance
@@ -78,6 +80,8 @@ def _build_instances_index():
         ip = instanceData.get("networkInterfaces", [{}])[0].get("accessConfigs", [{}])[0].get("natIP", None)
         if ip and not ip in INSTANCES_IP_INDEX:
             INSTANCES_IP_INDEX[ip] = instanceData
+            allInstanceData.append(instanceData)
+    INSTANCES_CACHE = allInstanceData
 
 def _get_data(use_cache, cache_expiration, group_name=None, region=None, zone=None):
     global INSTANCES_CACHE
@@ -126,9 +130,7 @@ def _get_data(use_cache, cache_expiration, group_name=None, region=None, zone=No
         else:
             raw_data = subprocess.check_output("gcloud compute instances list --format=json", shell=True)
             data = json.loads(raw_data)
-
-    INSTANCES_CACHE = data
-    _build_instances_index()
+    _build_instances_index(data)
     return data
 
 def _get_roles(data):

--- a/fabric_gce_tools/__init__.py
+++ b/fabric_gce_tools/__init__.py
@@ -234,6 +234,7 @@ __all__ = [
     "get_instance_zone_by_ip",
     "get_instance_zone_by_name",
     "get_instances_by_group",
+    "get_managed_instance_groups",
     "target_pool_add_instance",
     "target_pool_remove_instance"
 ]

--- a/fabric_gce_tools/__init__.py
+++ b/fabric_gce_tools/__init__.py
@@ -186,9 +186,7 @@ def get_instance_zone_by_ip(ip):
     return None
 
 def get_instances_by_group(group, region, zone):
-    if not _data_loaded:
-        update_roles_gce(group_name=group, region=region, zone=zone)
-    return data
+    return update_roles_gce(group_name=group, region=region, zone=zone)
 
 def target_pool_add_instance(target_pool_name, instance_name, instance_zone):
     raw_data = subprocess.check_output("gcloud compute target-pools add-instances {target_pool} --instances {instance_name} {zone_flag} {zone} --format json".format(target_pool=target_pool_name, instance_name=instance_name, zone_flag=_get_zone_flag_name(), zone=instance_zone), shell=True)
@@ -219,6 +217,7 @@ def update_roles_gce(use_cache=True, cache_expiration=86400, cache_path="~/.gcet
     env.roledefs.update(roles)
 
     _data_loaded = True
+    return data
 
 
 __all__ = [


### PR DESCRIPTION
This changeset adds a function called `get_instances_by_group`, which retrieves a list of instances from a managed GCE instance group rather than the global instances list.

Roles support is maintained (cool feature!) and it should support regional and zone-based instance groups (managed only, for now) just fine.

Feel free to squash - and I'm happy to revise with feedback 💯 

Neat library, thanks for publishing!