### PR TITLE
Able to use GCE public or private Ip addresses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email="eran@sandler.co.il",
     url="http://github.com/erans/fabric-gce-tools",
     packages=find_packages(),
-    install_requires=["fabric"],
+    install_requires=["fabric==1.14.0"],
 
     extras_require={
         "test": ["nose", "coverage", "mock"]


### PR DESCRIPTION
With this patch I would like to give the ability to either use GCE public or private Ip addresses. This could be useful when you want to run fabric from inside a gce machine to run commands on other machines of the same clusters without using the default public ip addresses. 